### PR TITLE
Fix typo where Fabric3 packaging is not correctly referenced.

### DIFF
--- a/fabric3-contribution-plugin/src/main/java/org/fabric3/contribution/Fabric3ContributionMojo.java
+++ b/fabric3-contribution-plugin/src/main/java/org/fabric3/contribution/Fabric3ContributionMojo.java
@@ -153,7 +153,7 @@ public class Fabric3ContributionMojo extends AbstractMojo {
     protected MavenProjectHelper projectHelper;
 
     /**
-     * @parameter property="project.packaging}
+     * @parameter property="project.packaging"
      * @required
      * @readonly
      */


### PR DESCRIPTION
This fix means jars have the proper extension of 'jar' not 'zip'.
