### PR TITLE
add jndi dependencies to the f3 assembly plugin extensions/jndi director...

### DIFF
--- a/fabric3-assembly-plugin/pom.xml
+++ b/fabric3-assembly-plugin/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>fabric3-assembly-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Fabric3 Runtime Assembly Plugin</name>
-    <version>2.5.4d</version>
+    <version>2.5.4-SNAPSHOT</version>
     <description>Fabric3 Runtime Assembly Plugin.</description>
 
    <dependencies>

--- a/fabric3-assembly-plugin/pom.xml
+++ b/fabric3-assembly-plugin/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>fabric3-assembly-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Fabric3 Runtime Assembly Plugin</name>
-    <version>2.5.4-SNAPSHOT</version>
+    <version>2.5.4d</version>
     <description>Fabric3 Runtime Assembly Plugin.</description>
 
    <dependencies>

--- a/fabric3-assembly-plugin/src/main/java/org/fabric3/assembly/Fabric3RuntimeAssemblyMojo.java
+++ b/fabric3-assembly-plugin/src/main/java/org/fabric3/assembly/Fabric3RuntimeAssemblyMojo.java
@@ -426,12 +426,12 @@ public class Fabric3RuntimeAssemblyMojo extends AbstractMojo {
      * @throws MojoExecutionException if there is an error during installation
      */
     private void installJndiDependencies(File rootDirectory) throws MojoExecutionException {
-        if (datasources == null || datasources.length == 0) {
+        if (jndiDependencies == null || jndiDependencies.length == 0) {
             return;
         }
         File repository = new File(rootDirectory, "extensions");
-        File datasourceDir = new File(repository, "jndi");
-        datasourceDir.mkdirs();
+        File jndiDir = new File(repository, "jndi");
+        jndiDir.mkdirs();
         for (Dependency dependency : jndiDependencies) {
             String groupId = dependency.getGroupId();
             String artifactId = dependency.getArtifactId();
@@ -452,7 +452,7 @@ public class Fabric3RuntimeAssemblyMojo extends AbstractMojo {
             OutputStream targetStream = null;
             try {
                 sourceStream = new BufferedInputStream(new FileInputStream(source));
-                File targetFile = new File(datasourceDir, source.getName());
+                File targetFile = new File(jndiDir, source.getName());
                 targetStream = new BufferedOutputStream(new FileOutputStream(targetFile));
                 copy(sourceStream, targetStream);
             } catch (IOException e) {

--- a/fabric3-assembly-plugin/src/main/java/org/fabric3/assembly/Fabric3RuntimeAssemblyMojo.java
+++ b/fabric3-assembly-plugin/src/main/java/org/fabric3/assembly/Fabric3RuntimeAssemblyMojo.java
@@ -142,6 +142,14 @@ public class Fabric3RuntimeAssemblyMojo extends AbstractMojo {
     public Dependency[] datasources = new Dependency[0];
 
     /**
+     * Set of jndi dependencies to install in the runtime.
+     *
+     * @parameter
+     */
+    public Dependency[] jndiDependencies = new Dependency[0];
+
+
+    /**
      * @component
      */
     public RepositorySystem repositorySystem;
@@ -184,6 +192,7 @@ public class Fabric3RuntimeAssemblyMojo extends AbstractMojo {
         installProfiles(rootDirectory);
         installExtensions(rootDirectory);
         installDatasources(rootDirectory);
+        installJndiDependencies(rootDirectory);
         installContributions(rootDirectory);
         installConfiguration(rootDirectory);
         removeExtensions(rootDirectory);
@@ -386,6 +395,51 @@ public class Fabric3RuntimeAssemblyMojo extends AbstractMojo {
             getLog().info("Installing datasource library: " + groupId + ":" + artifactId);
             Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier, type, version);
             //            Artifact artifact = artifactFactory.createArtifactWithClassifier(groupId, artifactId, version, type, classifier);
+            ArtifactResult result;
+            try {
+                result = repositorySystem.resolveArtifact(session, new ArtifactRequest(artifact, projectRepositories, null));
+            } catch (ArtifactResolutionException e) {
+                throw new MojoExecutionException(e.getMessage(), e);
+            }
+
+            File source = result.getArtifact().getFile();
+            InputStream sourceStream = null;
+            OutputStream targetStream = null;
+            try {
+                sourceStream = new BufferedInputStream(new FileInputStream(source));
+                File targetFile = new File(datasourceDir, source.getName());
+                targetStream = new BufferedOutputStream(new FileOutputStream(targetFile));
+                copy(sourceStream, targetStream);
+            } catch (IOException e) {
+                throw new MojoExecutionException(e.getMessage(), e);
+            } finally {
+                close(targetStream);
+                close(sourceStream);
+            }
+        }
+    }
+
+    /**
+     * Resolves and installs a set of configured jndi dependencies.
+     *
+     * @param rootDirectory the top-level runtime image directory
+     * @throws MojoExecutionException if there is an error during installation
+     */
+    private void installJndiDependencies(File rootDirectory) throws MojoExecutionException {
+        if (datasources == null || datasources.length == 0) {
+            return;
+        }
+        File repository = new File(rootDirectory, "extensions");
+        File datasourceDir = new File(repository, "jndi");
+        datasourceDir.mkdirs();
+        for (Dependency dependency : jndiDependencies) {
+            String groupId = dependency.getGroupId();
+            String artifactId = dependency.getArtifactId();
+            String version = dependency.getVersion();
+            String type = dependency.getType();
+            String classifier = dependency.getClassifier();
+            getLog().info("Installing jndi library: " + groupId + ":" + artifactId);
+            Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier, type, version);
             ArtifactResult result;
             try {
                 result = repositorySystem.resolveArtifact(session, new ArtifactRequest(artifact, projectRepositories, null));


### PR DESCRIPTION
...y

This change automates the population of the runtime image's extensions/jndi directory as described in https://fabric3.atlassian.net/wiki/display/FABRIC/Using+External+JMS+Providers based on a new section called `<jndiDependencies>` in the <configuration> section of the assembly plugin config in the pom.

e.g.

```
...
<jndiDependencies>
    <dependency>
        <groupId>org.apache.activemq</groupId>
        <artifactId>activemq-all</artifactId>
        <version>5.9.1</version>
    </dependency>
</jndiDependencies>
...
```
